### PR TITLE
Add support for `llms-small.txt`

### DIFF
--- a/.changeset/empty-carrots-grow.md
+++ b/.changeset/empty-carrots-grow.md
@@ -1,0 +1,5 @@
+---
+"starlight-llms-txt": minor
+---
+
+Adds support for generating a smaller `llms-small.txt` file for smaller context windows

--- a/.changeset/spotty-crabs-relax.md
+++ b/.changeset/spotty-crabs-relax.md
@@ -1,0 +1,5 @@
+---
+"starlight-llms-txt": patch
+---
+
+Sort pages in llms.txt output

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
 				starlightLlmsTxt({
 					description:
 						'starlight-llms-txt is a plugin for the Starlight documentation website framework that auto-generates llms.txt context files for large language models based on a documentation site’s content.',
+					// Exclude landing page from llms-small.txt
+					exclude: ['index'],
 				}),
 			],
 			sidebar: ['getting-started', 'configuration'],

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -90,23 +90,73 @@ exclude: ['old-page', 'tutorial/**'],
 
 ### `minify`
 
-**Type:** `Record<'note' | 'tip' | 'caution' | 'danger' | 'details' | 'whitespace', boolean>`
-
 A map of content types to filter out of docs when creating `llms-small.txt` for small context windows.
 Set an element to `true` to filter it out or to `false` to keep it.
 
-By default, the following minify values are used:
+Use the [`customSelectors`](#minifycustomselectors) option to provide an array of additional CSS-style selectors that match elements to exclude.
+
+In the following example, the default exclusion of notes is overridden and a custom in-page navigation component is added to the elements to exclude:
 
 ```ts
 minify: {
-	// Starlight aside variants
-	note: true,
-	tip: true,
-	caution: false,
-	danger: false,
-	// HTML elements
-	details: true,
-	// Whether whitespace should be collapsed
-	whitespace: true,
+	note: false,
+	customSelectors: ['.my-page-nav'],
 },
 ```
+
+#### `minify.customSelectors`
+
+**Type:** `string[]`  
+**Default:** `[]`
+
+Specify custom CSS-style selectors to exclude.
+Selectors are tested with [`hast-util-select`’s matching features](https://github.com/syntax-tree/hast-util-select#support) and should match your site’s HTML output.
+
+In the following example, `customSelectors` is used to exclude an `<interactive-demo>` custom element and an element showing a project’s sponsors that has the `sponsors-banner` class name:
+
+```ts
+customSelectors: ['interactive-demo', '.sponsors-banner'],
+```
+
+#### `minify.note`
+
+**Type:** `boolean`  
+**Default:** `true`
+
+Exclude the `note` variant of Starlight’s aside component.
+
+#### `minify.tip`
+
+**Type:** `boolean`  
+**Default:** `true`
+
+Exclude the `tip` variant of Starlight’s aside component.
+
+#### `minify.caution`
+
+**Type:** `boolean`  
+**Default:** `false`
+
+Exclude the `caution` variant of Starlight’s aside component.
+
+#### `minify.danger`
+
+**Type:** `boolean`  
+**Default:** `false`
+
+Exclude the `danger` variant of Starlight’s aside component.
+
+#### `minify.details`
+
+**Type:** `boolean`  
+**Default:** `true`
+
+Exclude the `<details>` HTML element.
+
+#### `minify.whitespace`
+
+**Type:** `boolean`  
+**Default:** `true`
+
+Collapse whitespace.
+When `minify.whitespace` is set to `true`, all whitespace — including new lines — is collapsed to a single space character.

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -70,3 +70,24 @@ Provide addition details to add after the `description` in `llms.txt`.
 According to [llmstxt.org](https://llmstxt.org/) this should be:
 
 > Zero or more markdown sections (e.g. paragraphs, lists, etc) of any type except headings, containing more detailed information about the project and how to interpret the provided files
+
+### `minify`
+
+**Type:** `Record<'note' | 'tip' | 'caution' | 'danger' | 'details', boolean>`
+
+A map of element types to filter out of docs when creating `llms-small.txt` for small context windows.
+Set an element to `true` to filter it out or to `false` to keep it.
+
+By default, the following minify values are used:
+
+```ts
+minify: {
+	// Starlight aside variants
+	note: true,
+	tip: true,
+	caution: false,
+	danger: false,
+	// HTML elements
+	details: true,
+},
+```

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -73,9 +73,9 @@ According to [llmstxt.org](https://llmstxt.org/) this should be:
 
 ### `minify`
 
-**Type:** `Record<'note' | 'tip' | 'caution' | 'danger' | 'details', boolean>`
+**Type:** `Record<'note' | 'tip' | 'caution' | 'danger' | 'details' | 'whitespace', boolean>`
 
-A map of element types to filter out of docs when creating `llms-small.txt` for small context windows.
+A map of content types to filter out of docs when creating `llms-small.txt` for small context windows.
 Set an element to `true` to filter it out or to `false` to keep it.
 
 By default, the following minify values are used:
@@ -89,5 +89,7 @@ minify: {
 	danger: false,
 	// HTML elements
 	details: true,
+	// Whether whitespace should be collapsed
+	whitespace: true,
 },
 ```

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -71,6 +71,23 @@ According to [llmstxt.org](https://llmstxt.org/) this should be:
 
 > Zero or more markdown sections (e.g. paragraphs, lists, etc) of any type except headings, containing more detailed information about the project and how to interpret the provided files
 
+### `exclude`
+
+**Type:** `string[]`  
+**Default:** `[]`
+
+Use the `exclude` option to specify docs pages that should be excluded when generating `llms-small.txt`.
+This allows you to filter out non-essential documentation for models with a smaller context window.
+
+The value of `exclude` is an array of page slugs or glob patterns that match page slugs.
+Glob patterns are processed using [`micromatch`’s matching features](https://github.com/micromatch/micromatch#matching-features).
+
+In the following example, a specific, outdated page is excluded as well as all pages in the `src/content/docs/tutorial/` directory:
+
+```ts
+exclude: ['old-page', 'tutorial/**'],
+```
+
 ### `minify`
 
 **Type:** `Record<'note' | 'tip' | 'caution' | 'danger' | 'details' | 'whitespace', boolean>`

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -3,7 +3,7 @@ title: Getting Started
 description: How to install and set-up starlight-llms-txt in your Starlight docs site
 ---
 
-`starlight-llms-txt` is a plugin for the [Starlight](https://starlight.astro.build/) documentation website framework that auto-generates `llms.txt` and `llms-full.txt` context files for large language models based on your documentation site’s content.
+`starlight-llms-txt` is a plugin for the [Starlight](https://starlight.astro.build/) documentation website framework that auto-generates `llms.txt`, `llms-full.txt`, and `llms-small.txt` context files for large language models based on your documentation site’s content.
 
 You can learn more about `llms.txt` files at [llmstxt.org](https://llmstxt.org/).
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -81,6 +81,12 @@ import { Card, CardGrid, Tabs, TabItem } from '@astrojs/starlight/components';
     			title="llms-full.txt file for this site"
     		></iframe>
     	</TabItem>
+    	<TabItem label="llms-small.txt">
+    		<iframe
+    			src="/starlight-llms-txt/llms-small.txt"
+    			title="llms-small.txt file for this site"
+    		></iframe>
+    	</TabItem>
     </Tabs>
 
 </div>
@@ -89,7 +95,8 @@ import { Card, CardGrid, Tabs, TabItem } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
 	<Card title="Install the plugin" icon="puzzle">
-		Check the [getting started guide](/starlight-llms-txt/getting-started/) for installation instructions.
+		Check the [getting started guide](/starlight-llms-txt/getting-started/) for installation
+		instructions.
 	</Card>
 	<Card title="Configure the plugin" icon="setting">
 		Edit your config in the `astro.config.mjs` file.

--- a/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
+++ b/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
@@ -35,9 +35,16 @@ const htmlToMarkdownPipeline = unified()
 	.use(remarkStringify);
 
 /** Render a content collection entry to HTML and back to Markdown to support rendering and simplifying MDX components */
-export async function entryToSimpleMarkdown(entry: CollectionEntry<'docs'>, context: APIContext) {
+export async function entryToSimpleMarkdown(
+	entry: CollectionEntry<'docs'>,
+	context: APIContext,
+	minify: boolean = false
+) {
 	const { Content } = await render(entry);
 	const html = await astroContainer.renderToString(Content, context);
-	const file = await htmlToMarkdownPipeline.process(html);
+	const file = await htmlToMarkdownPipeline.process({
+		value: html,
+		data: { starlightLlmsTxt: { minify } },
+	});
 	return String(file);
 }

--- a/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
+++ b/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
@@ -37,28 +37,30 @@ const htmlToMarkdownPipeline = unified()
 			if (!file.data.starlightLlmsTxt.minify) {
 				return;
 			}
-			remove(tree, (node) => {
+			remove(tree, (_node) => {
+				const node = _node as RootContent;
 				// Remove <details> elements:
 				if (minify.details && isElement(node, 'details')) {
 					return true;
 				}
 
+				// Remove elements matching a user’s custom selectors:
 				for (const selector of minify.customSelectors) {
-					if (matches(selector, node as RootContent)) {
+					if (matches(selector, node)) {
 						return true;
 					}
 				}
 
 				// Remove aside components:
-				return Boolean(
-					isElement(node, 'aside') &&
-						Array.isArray(node.properties.className) &&
-						node.properties.className.includes('starlight-aside') &&
-						((minify.note && node.properties.className.includes('starlight-aside--note')) ||
-							(minify.tip && node.properties.className.includes('starlight-aside--tip')) ||
-							(minify.caution && node.properties.className.includes('starlight-aside--caution')) ||
-							(minify.danger && node.properties.className.includes('starlight-aside--danger')))
-				);
+				if (matches('.starlight-aside', node)) {
+					for (const variant of ['note', 'tip', 'caution', 'danger'] as const) {
+						if (minify[variant] && matches(`.starlight-aside--${variant}`, node)) {
+							return true;
+						}
+					}
+				}
+
+				return false;
 			});
 			return tree;
 		};

--- a/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
+++ b/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
@@ -2,8 +2,9 @@ import mdxServer from '@astrojs/mdx/server.js';
 import type { APIContext } from 'astro';
 import { experimental_AstroContainer } from 'astro/container';
 import { render, type CollectionEntry } from 'astro:content';
+import type { RootContent } from 'hast';
 import { isElement } from 'hast-util-is-element';
-import { select, selectAll } from 'hast-util-select';
+import { matches, select, selectAll } from 'hast-util-select';
 import rehypeParse from 'rehype-parse';
 import rehypeRemark from 'rehype-remark';
 import remarkGfm from 'remark-gfm';
@@ -20,6 +21,7 @@ const minifyDefaults = {
 	danger: false,
 	details: true,
 	whitespace: true,
+	customSelectors: [],
 };
 /** Resolved minification options */
 const minify = { ...minifyDefaults, ...starlightLllmsTxtContext.minify };
@@ -39,6 +41,12 @@ const htmlToMarkdownPipeline = unified()
 				// Remove <details> elements:
 				if (minify.details && isElement(node, 'details')) {
 					return true;
+				}
+
+				for (const selector of minify.customSelectors) {
+					if (matches(selector, node as RootContent)) {
+						return true;
+					}
 				}
 
 				// Remove aside components:

--- a/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
+++ b/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
@@ -13,7 +13,14 @@ import { remove } from 'unist-util-remove';
 import { starlightLllmsTxtContext } from 'virtual:starlight-llms-txt/context';
 
 /** Minification defaults */
-const minifyDefaults = { note: true, tip: true, caution: false, danger: false, details: true };
+const minifyDefaults = {
+	note: true,
+	tip: true,
+	caution: false,
+	danger: false,
+	details: true,
+	whitespace: true,
+};
 /** Resolved minification options */
 const minify = { ...minifyDefaults, ...starlightLllmsTxtContext.minify };
 
@@ -71,13 +78,17 @@ const htmlToMarkdownPipeline = unified()
 export async function entryToSimpleMarkdown(
 	entry: CollectionEntry<'docs'>,
 	context: APIContext,
-	minify: boolean = false
+	shouldMinify: boolean = false
 ) {
 	const { Content } = await render(entry);
 	const html = await astroContainer.renderToString(Content, context);
 	const file = await htmlToMarkdownPipeline.process({
 		value: html,
-		data: { starlightLlmsTxt: { minify } },
+		data: { starlightLlmsTxt: { minify: shouldMinify } },
 	});
-	return String(file);
+	let markdown = String(file).trim();
+	if (shouldMinify && minify.whitespace) {
+		markdown = markdown.replace(/\s+/g, ' ');
+	}
+	return markdown;
 }

--- a/packages/starlight-llms-txt/env.d.ts
+++ b/packages/starlight-llms-txt/env.d.ts
@@ -3,3 +3,11 @@
 declare module 'virtual:starlight-llms-txt/context' {
 	export const starlightLllmsTxtContext: import('./types').ProjectContext;
 }
+
+declare module 'vfile' {
+	interface DataMap {
+		starlightLlmsTxt: {
+			minify: boolean;
+		};
+	}
+}

--- a/packages/starlight-llms-txt/generator.ts
+++ b/packages/starlight-llms-txt/generator.ts
@@ -1,0 +1,29 @@
+import type { APIContext } from 'astro';
+import { getCollection } from 'astro:content';
+import { entryToSimpleMarkdown } from './entryToSimpleMarkdown';
+import { getSiteTitle, isDefaultLocale } from './utils';
+
+/**
+ * Generates a single plaintext Markdown document from the full website content.
+ */
+export async function generateLlmsTxt(
+	context: APIContext,
+	options: {
+		/** Generate a smaller file to fit within smaller context windows. */
+		minify: boolean;
+	}
+): Promise<string> {
+	const docs = await getCollection('docs', isDefaultLocale);
+	const segments: string[] = [];
+	for (const doc of docs) {
+		const docSegments = [`# ${doc.data.hero?.title || doc.data.title}`];
+		const description = doc.data.hero?.tagline || doc.data.description;
+		if (description) docSegments.push(`> ${description}`);
+		docSegments.push(await entryToSimpleMarkdown(doc, context, options.minify));
+		segments.push(docSegments.join('\n\n'));
+	}
+	const preamble = `<SYSTEM>This is the ${
+		options.minify ? 'abridged' : 'full'
+	} developer documentation for ${getSiteTitle()}</SYSTEM>`;
+	return preamble + '\n\n' + segments.join('\n\n');
+}

--- a/packages/starlight-llms-txt/generator.ts
+++ b/packages/starlight-llms-txt/generator.ts
@@ -1,5 +1,7 @@
 import type { APIContext } from 'astro';
 import { getCollection } from 'astro:content';
+import micromatch from 'micromatch';
+import { starlightLllmsTxtContext } from 'virtual:starlight-llms-txt/context';
 import { entryToSimpleMarkdown } from './entryToSimpleMarkdown';
 import { defaultLang, getSiteTitle, isDefaultLocale } from './utils';
 
@@ -16,11 +18,13 @@ export async function generateLlmsTxt(
 		minify: boolean;
 	}
 ): Promise<string> {
-	const docs = (await getCollection('docs', isDefaultLocale)).sort((a, b) => {
-		const aIsIndex = a.id === 'index';
-		const bIsIndex = b.id === 'index';
-		return aIsIndex && !bIsIndex ? -1 : bIsIndex && !aIsIndex ? 1 : collator.compare(a.id, b.id);
-	});
+	const docs = (await getCollection('docs', isDefaultLocale))
+		.filter((doc) => !micromatch.isMatch(doc.id, starlightLllmsTxtContext.exclude))
+		.sort((a, b) => {
+			const aIsIndex = a.id === 'index';
+			const bIsIndex = b.id === 'index';
+			return aIsIndex && !bIsIndex ? -1 : bIsIndex && !aIsIndex ? 1 : collator.compare(a.id, b.id);
+		});
 	const segments: string[] = [];
 	for (const doc of docs) {
 		const docSegments = [`# ${doc.data.hero?.title || doc.data.title}`];

--- a/packages/starlight-llms-txt/index.ts
+++ b/packages/starlight-llms-txt/index.ts
@@ -25,6 +25,10 @@ export default function starlightLlmsTxt(opts: StarlightLllmsTextOptions = {}): 
 								entrypoint: new URL('./llms-full.txt.ts', import.meta.url),
 								pattern: '/llms-full.txt',
 							});
+							injectRoute({
+								entrypoint: new URL('./llms-small.txt.ts', import.meta.url),
+								pattern: '/llms-small.txt',
+							});
 
 							const projectContext: ProjectContext = {
 								base: astroConfig.base,

--- a/packages/starlight-llms-txt/index.ts
+++ b/packages/starlight-llms-txt/index.ts
@@ -36,6 +36,7 @@ export default function starlightLlmsTxt(opts: StarlightLllmsTextOptions = {}): 
 								description: opts.description ?? config.description,
 								details: opts.details,
 								minify: opts.minify ?? {},
+								exclude: opts.exclude ?? [],
 								defaultLocale: config.defaultLocale,
 								locales: config.locales,
 							};

--- a/packages/starlight-llms-txt/index.ts
+++ b/packages/starlight-llms-txt/index.ts
@@ -35,6 +35,7 @@ export default function starlightLlmsTxt(opts: StarlightLllmsTextOptions = {}): 
 								title: opts.projectName ?? config.title,
 								description: opts.description ?? config.description,
 								details: opts.details,
+								minify: opts.minify ?? {},
 								defaultLocale: config.defaultLocale,
 								locales: config.locales,
 							};

--- a/packages/starlight-llms-txt/llms-small.txt.ts
+++ b/packages/starlight-llms-txt/llms-small.txt.ts
@@ -5,6 +5,6 @@ import { generateLlmsTxt } from './generator';
  * Route that generates a single plaintext Markdown document from the full website content.
  */
 export const GET: APIRoute = async (context) => {
-	const body = await generateLlmsTxt(context, { minify: false });
+	const body = await generateLlmsTxt(context, { minify: true });
 	return new Response(body);
 };

--- a/packages/starlight-llms-txt/llms.txt.ts
+++ b/packages/starlight-llms-txt/llms.txt.ts
@@ -12,6 +12,7 @@ export const GET: APIRoute = async (context) => {
 		: '';
 	const site = new URL(ensureTrailingSlash(starlightLllmsTxtContext.base), context.site);
 	const llmsFullLink = new URL('./llms-full.txt', site);
+	const llmsSmallLink = new URL('./llms-small.txt', site);
 
 	const segments = [`# ${title}`];
 	if (description) segments.push(description);
@@ -20,7 +21,9 @@ export const GET: APIRoute = async (context) => {
 	// Further documentation links.
 	segments.push(`## Documentation Sets`);
 	segments.push(
-		`- [Complete documentation](${llmsFullLink}): the full documentation for ${getSiteTitle()}`
+		`- [Abridged documentation](${llmsSmallLink}): a compact version of the documentation for ${getSiteTitle()}, with non-essential content removed` +
+			'\n' +
+			`- [Complete documentation](${llmsFullLink}): the full documentation for ${getSiteTitle()}`
 	);
 
 	// Additional notes.

--- a/packages/starlight-llms-txt/package.json
+++ b/packages/starlight-llms-txt/package.json
@@ -10,8 +10,10 @@
 	},
 	"dependencies": {
 		"@astrojs/mdx": "^4.0.5",
+		"@types/micromatch": "^4.0.9",
 		"hast-util-is-element": "^3.0.0",
 		"hast-util-select": "^6.0.3",
+		"micromatch": "^4.0.8",
 		"rehype-parse": "^9.0.1",
 		"rehype-remark": "^10.0.0",
 		"remark-gfm": "^4.0.0",

--- a/packages/starlight-llms-txt/package.json
+++ b/packages/starlight-llms-txt/package.json
@@ -10,12 +10,14 @@
 	},
 	"dependencies": {
 		"@astrojs/mdx": "^4.0.5",
+		"hast-util-is-element": "^3.0.0",
 		"hast-util-select": "^6.0.3",
 		"rehype-parse": "^9.0.1",
 		"rehype-remark": "^10.0.0",
 		"remark-gfm": "^4.0.0",
 		"remark-stringify": "^11.0.0",
-		"unified": "^11.0.5"
+		"unified": "^11.0.5",
+		"unist-util-remove": "^4.0.0"
 	},
 	"devDependencies": {
 		"@astrojs/starlight": "^0.31.0",

--- a/packages/starlight-llms-txt/package.json
+++ b/packages/starlight-llms-txt/package.json
@@ -12,7 +12,6 @@
 		"@astrojs/mdx": "^4.0.5",
 		"@types/hast": "^3.0.4",
 		"@types/micromatch": "^4.0.9",
-		"hast-util-is-element": "^3.0.0",
 		"hast-util-select": "^6.0.3",
 		"micromatch": "^4.0.8",
 		"rehype-parse": "^9.0.1",

--- a/packages/starlight-llms-txt/package.json
+++ b/packages/starlight-llms-txt/package.json
@@ -10,6 +10,7 @@
 	},
 	"dependencies": {
 		"@astrojs/mdx": "^4.0.5",
+		"@types/hast": "^3.0.4",
 		"@types/micromatch": "^4.0.9",
 		"hast-util-is-element": "^3.0.0",
 		"hast-util-select": "^6.0.3",

--- a/packages/starlight-llms-txt/types.ts
+++ b/packages/starlight-llms-txt/types.ts
@@ -9,6 +9,7 @@ export interface ProjectContext {
 	title: StarlightUserConfig['title'];
 	description: StarlightUserConfig['description'];
 	details: StarlightLllmsTextOptions['details'];
+	minify: NonNullable<StarlightLllmsTextOptions['minify']>;
 }
 
 /** Plugin user options. */
@@ -58,4 +59,33 @@ export interface StarlightLllmsTextOptions {
 	 * ```
 	 */
 	details?: string;
+
+	/** Control what elements are removed in `llms-small.txt`. */
+	minify?: {
+		/**
+		 * Remove Starlight note asides in `llms-small.txt`.
+		 * @default true
+		 */
+		note?: boolean;
+		/**
+		 * Remove Starlight tip asides in `llms-small.txt`.
+		 * @default true
+		 */
+		tip?: boolean;
+		/**
+		 * Remove Starlight caution asides in `llms-small.txt`.
+		 * @default false
+		 */
+		caution?: boolean;
+		/**
+		 * Remove Starlight danger asides in `llms-small.txt`.
+		 * @default false
+		 */
+		danger?: boolean;
+		/**
+		 * Remove HTML `<details>` elements in `llms-small.txt`.
+		 * @default true
+		 */
+		details?: boolean;
+	};
 }

--- a/packages/starlight-llms-txt/types.ts
+++ b/packages/starlight-llms-txt/types.ts
@@ -93,17 +93,27 @@ export interface StarlightLllmsTextOptions {
 		 * @default true
 		 */
 		whitespace?: boolean;
+
+		/**
+		 * Custom selectors to exclude when generating `llms-small.txt`.
+		 *
+		 * @default []
+		 *
+		 * @example
+		 * // Filter out elements with the class name `sponsors` when creating llms-small.txt
+		 * customSelectors: [".sponsors"],
+		 */
+		customSelectors?: string[];
 	};
 
 	/**
 	 * Slugs of pages to exclude from `llms-small.txt`. Supports glob patterns.
 	 *
+	 * @default []
+	 *
 	 * @example
 	 * // Ignore an old page and all tutorial pages when creating llms-small.txt
-	 * exclude: [
-	 * 	"old-page",
-	 * 	"tutorial/**"
-	 * ],
+	 * exclude: ["old-page", "tutorial/**"],
 	 */
 	exclude?: string[];
 }

--- a/packages/starlight-llms-txt/types.ts
+++ b/packages/starlight-llms-txt/types.ts
@@ -87,5 +87,10 @@ export interface StarlightLllmsTextOptions {
 		 * @default true
 		 */
 		details?: boolean;
+		/**
+		 * Collapse whitespace in `llms-small.txt`.
+		 * @default true
+		 */
+		whitespace?: boolean;
 	};
 }

--- a/packages/starlight-llms-txt/types.ts
+++ b/packages/starlight-llms-txt/types.ts
@@ -10,6 +10,7 @@ export interface ProjectContext {
 	description: StarlightUserConfig['description'];
 	details: StarlightLllmsTextOptions['details'];
 	minify: NonNullable<StarlightLllmsTextOptions['minify']>;
+	exclude: NonNullable<StarlightLllmsTextOptions['exclude']>;
 }
 
 /** Plugin user options. */
@@ -93,4 +94,16 @@ export interface StarlightLllmsTextOptions {
 		 */
 		whitespace?: boolean;
 	};
+
+	/**
+	 * Slugs of pages to exclude from `llms-small.txt`. Supports glob patterns.
+	 *
+	 * @example
+	 * // Ignore an old page and all tutorial pages when creating llms-small.txt
+	 * exclude: [
+	 * 	"old-page",
+	 * 	"tutorial/**"
+	 * ],
+	 */
+	exclude?: string[];
 }

--- a/packages/starlight-llms-txt/utils.ts
+++ b/packages/starlight-llms-txt/utils.ts
@@ -2,7 +2,7 @@ import type { CollectionEntry } from 'astro:content';
 import { starlightLllmsTxtContext } from 'virtual:starlight-llms-txt/context';
 
 const { defaultLocale, locales, title } = starlightLllmsTxtContext;
-const defaultLang = (defaultLocale === 'root' ? locales?.root?.lang : defaultLocale) || 'en';
+export const defaultLang = (defaultLocale === 'root' ? locales?.root?.lang : defaultLocale) || 'en';
 
 /** Get the site title from the Starlight config. */
 export function getSiteTitle(): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@astrojs/mdx':
         specifier: ^4.0.5
         version: 4.0.5(astro@5.1.6(rollup@4.30.1)(typescript@5.7.3))
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@types/micromatch':
         specifier: ^4.0.9
         version: 4.0.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@astrojs/mdx':
         specifier: ^4.0.5
         version: 4.0.5(astro@5.1.6(rollup@4.30.1)(typescript@5.7.3))
+      hast-util-is-element:
+        specifier: ^3.0.0
+        version: 3.0.0
       hast-util-select:
         specifier: ^6.0.3
         version: 6.0.3
@@ -56,6 +59,9 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      unist-util-remove:
+        specifier: ^4.0.0
+        version: 4.0.0
     devDependencies:
       '@astrojs/starlight':
         specifier: ^0.31.0
@@ -2083,6 +2089,9 @@ packages:
 
   unist-util-remove-position@5.0.0:
     resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
+
+  unist-util-remove@4.0.0:
+    resolution: {integrity: sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
@@ -4932,6 +4941,12 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-visit: 5.0.0
+
+  unist-util-remove@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
 
   unist-util-stringify-position@4.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       '@types/micromatch':
         specifier: ^4.0.9
         version: 4.0.9
-      hast-util-is-element:
-        specifier: ^3.0.0
-        version: 3.0.0
       hast-util-select:
         specifier: ^6.0.3
         version: 6.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,12 +38,18 @@ importers:
       '@astrojs/mdx':
         specifier: ^4.0.5
         version: 4.0.5(astro@5.1.6(rollup@4.30.1)(typescript@5.7.3))
+      '@types/micromatch':
+        specifier: ^4.0.9
+        version: 4.0.9
       hast-util-is-element:
         specifier: ^3.0.0
         version: 3.0.0
       hast-util-select:
         specifier: ^6.0.3
         version: 6.0.3
+      micromatch:
+        specifier: ^4.0.8
+        version: 4.0.8
       rehype-parse:
         specifier: ^9.0.1
         version: 9.0.1
@@ -780,6 +786,9 @@ packages:
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
+  '@types/braces@3.0.5':
+    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -803,6 +812,9 @@ packages:
 
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+
+  '@types/micromatch@4.0.9':
+    resolution: {integrity: sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==}
 
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
@@ -3003,6 +3015,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.6
 
+  '@types/braces@3.0.5': {}
+
   '@types/cookie@0.6.0': {}
 
   '@types/debug@4.1.12':
@@ -3026,6 +3040,10 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/mdx@2.0.13': {}
+
+  '@types/micromatch@4.0.9':
+    dependencies:
+      '@types/braces': 3.0.5
 
   '@types/ms@0.7.34': {}
 


### PR DESCRIPTION
- Adds a new `llms-small.txt` output file
- Adds configuration options to help configure what is excluded in this file
- Sorts output files by file slug to help group related pages a bit