### PR TITLE
Add config options to promote or demote pages

### DIFF
--- a/.changeset/violet-berries-study.md
+++ b/.changeset/violet-berries-study.md
@@ -1,0 +1,5 @@
+---
+"starlight-llms-txt": minor
+---
+
+Adds options to promote or demote pages in the order of the `llms-full.txt` and `llms-small.tt` output files

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -86,7 +86,9 @@ Use it for secondary information which is not already in your docs content.
 **Type:** `string[]`  
 **Default:** `['index*']`
 
-Micromatch expressions to match page IDs that should be sorted to the top of the output.
+Use the `promote` option to specify pages that should be sorted to the top of the `llms-full.txt` and `llms-small.txt` files.
+The value should be an array of page slugs or glob patterns that match page slugs.
+Glob patterns are processed using [`micromatch`’s matching features](https://github.com/micromatch/micromatch#matching-features).
 
 The default value promotes the index page. If you'd like to promote more or other pages, add them to the array:
 
@@ -101,10 +103,11 @@ promote: ['index*', 'getting-started*', '!*/*'],
 **Type:** `string[]`  
 **Default:** `[]`
 
-Micromatch expressions to match page IDs that should be sorted to the end of the output.
+Use the `demote` option to specify pages that should be sorted to the bottom of the `llms-full.txt` and `llms-small.txt` files.
+The value should be an array of page slugs or glob patterns that match page slugs.
+Glob patterns are processed using [`micromatch`’s matching features](https://github.com/micromatch/micromatch#matching-features).
 
-If a page matches both `promote` and `demote`, it will be demoted.
-
+If a page matches patterns in both `promote` and `demote`, it will be demoted.
 ### `exclude`
 
 **Type:** `string[]`  

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -84,13 +84,15 @@ Use it for secondary information which is not already in your docs content.
 ### `promote`
 
 **Type:** `string[]`  
-**Default:** `['index*', 'getting-started*', '!*/*']`
+**Default:** `['index*']`
 
 Micromatch expressions to match page IDs that should be sorted to the top of the output.
 
-The default value promotes the pages `index` and `getting-started` to the top of the list, followed by any pages in the root directory of the docs.
+The default value promotes the index page. If you'd like to promote more or other pages, add them to the array:
 
 ```ts
+// Example: In addition to the index page, also promote `getting-started`
+// and any pages in the root directory to the top of the output
 promote: ['index*', 'getting-started*', '!*/*'],
 ```
 

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -81,6 +81,28 @@ An array of optional links to add to the `llms.txt` entrypoint.
 URLs provided here can be skipped by the LLM if a shorter context is needed.
 Use it for secondary information which is not already in your docs content.
 
+### `promote`
+
+**Type:** `string[]`  
+**Default:** `['index*', 'getting-started*', '!*/*']`
+
+Micromatch expressions to match page IDs that should be sorted to the top of the output.
+
+The default value promotes the pages `index` and `getting-started` to the top of the list, followed by any pages in the root directory of the docs.
+
+```ts
+promote: ['index*', 'getting-started*', '!*/*'],
+```
+
+### `demote`
+
+**Type:** `string[]`  
+**Default:** `[]`
+
+Micromatch expressions to match page IDs that should be sorted to the end of the output.
+
+If a page matches both `promote` and `demote`, it will be demoted.
+
 ### `exclude`
 
 **Type:** `string[]`  

--- a/packages/starlight-llms-txt/generator.ts
+++ b/packages/starlight-llms-txt/generator.ts
@@ -23,9 +23,17 @@ export async function generateLlmsTxt(
 		docs = docs.filter((doc) => !micromatch.isMatch(doc.id, starlightLllmsTxtContext.exclude));
 	}
 	const { promote, demote } = starlightLllmsTxtContext;
+	/** Processes page IDs by prepending underscores to influence the sorting order. */
 	const prioritizePages = (id: string) => {
+		// Match the page ID against the patterns listed in the `promote` and `demote`
+		// config options and return the index of the first match. If a page matches
+		// a `demote` pattern, we don't check `promote` as demotions take precedence.
 		const demoted = demote.findIndex((expr) => micromatch.isMatch(id, expr));
 		const promoted = demoted > -1 ? -1 : promote.findIndex((expr) => micromatch.isMatch(id, expr));
+		// Calculate the number of underscores to prefix the page ID with
+		// to influence the sorting order. The more underscores, the earlier
+		// the page will appear in the list. The amount of underscores added by
+		// a pattern is determined by the respective array length and the match index.
 		const prefixLength = (promoted > -1 ? promote.length - promoted : 0) + demote.length - demoted - 1;
 		return '_'.repeat(prefixLength) + id;
 	};

--- a/packages/starlight-llms-txt/index.ts
+++ b/packages/starlight-llms-txt/index.ts
@@ -37,6 +37,8 @@ export default function starlightLlmsTxt(opts: StarlightLllmsTextOptions = {}): 
 								details: opts.details,
 								optionalLinks: opts.optionalLinks ?? [],
 								minify: opts.minify ?? {},
+								promote: opts.promote ?? ['index*', 'getting-started*', '!*/*'],
+								demote: opts.demote ?? [],
 								exclude: opts.exclude ?? [],
 								defaultLocale: config.defaultLocale,
 								locales: config.locales,

--- a/packages/starlight-llms-txt/index.ts
+++ b/packages/starlight-llms-txt/index.ts
@@ -37,7 +37,7 @@ export default function starlightLlmsTxt(opts: StarlightLllmsTextOptions = {}): 
 								details: opts.details,
 								optionalLinks: opts.optionalLinks ?? [],
 								minify: opts.minify ?? {},
-								promote: opts.promote ?? ['index*', 'getting-started*', '!*/*'],
+								promote: opts.promote ?? ['index*'],
 								demote: opts.demote ?? [],
 								exclude: opts.exclude ?? [],
 								defaultLocale: config.defaultLocale,

--- a/packages/starlight-llms-txt/types.ts
+++ b/packages/starlight-llms-txt/types.ts
@@ -11,6 +11,8 @@ export interface ProjectContext {
 	details: StarlightLllmsTextOptions['details'];
 	optionalLinks: NonNullable<StarlightLllmsTextOptions['optionalLinks']>;
 	minify: NonNullable<StarlightLllmsTextOptions['minify']>;
+	promote: NonNullable<StarlightLllmsTextOptions['promote']>;
+	demote: NonNullable<StarlightLllmsTextOptions['demote']>;
 	exclude: NonNullable<StarlightLllmsTextOptions['exclude']>;
 }
 
@@ -118,6 +120,25 @@ export interface StarlightLllmsTextOptions {
 		 */
 		customSelectors?: string[];
 	};
+
+	/**
+	 * Micromatch expressions to match page IDs that should be sorted to the top of the output.
+	 *
+	 * @default
+	 * // Note that there is not actually a space in the last expression,
+	 * // removing it would close this JSDoc comment.
+	 * ['index*', 'getting-started*', '!* /*']
+	 */
+	promote?: string[];
+
+	/**
+	 * Micromatch expressions to match page IDs that should be sorted to the end of the output.
+	 *
+	 * If a page matches both `promote` and `demote`, it will be demoted.
+	 *
+	 * @default []
+	 */
+	demote?: string[];
 
 	/**
 	 * Slugs of pages to exclude from `llms-small.txt`. Supports glob patterns.

--- a/packages/starlight-llms-txt/types.ts
+++ b/packages/starlight-llms-txt/types.ts
@@ -125,9 +125,7 @@ export interface StarlightLllmsTextOptions {
 	 * Micromatch expressions to match page IDs that should be sorted to the top of the output.
 	 *
 	 * @default
-	 * // Note that there is not actually a space in the last expression,
-	 * // removing it would close this JSDoc comment.
-	 * ['index*', 'getting-started*', '!* /*']
+	 * ['index*']
 	 */
 	promote?: string[];
 


### PR DESCRIPTION
Adds two config options `promote` and `demote` that allow influencing the order in which pages are sorted when generating the output files.

I'm using these for my own docs and thought you might find them useful, too (at least until the plugin is able to respect the sidebar order).