### PR TITLE
Add exclusion option to llms-full.txt API response

### DIFF
--- a/packages/starlight-llms-txt/llms-full.txt.ts
+++ b/packages/starlight-llms-txt/llms-full.txt.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from 'astro';
+import { starlightLllmsTxtContext } from 'virtual:starlight-llms-txt/context';
 import { generateLlmsTxt } from './generator';
 import { getSiteTitle } from './utils';
 
@@ -9,6 +10,7 @@ export const GET: APIRoute = async (context) => {
 	const body = await generateLlmsTxt(context, {
 		minify: false,
 		description: `This is the full developer documentation for ${getSiteTitle()}`,
+	    exclude: starlightLllmsTxtContext.exclude,
 	});
 	return new Response(body);
 };


### PR DESCRIPTION
This pull request introduces a small update to how the `generateLlmsTxt` function is called in `llms-full.txt.ts`. The change ensures that the `exclude` property from the `starlightLllmsTxtContext` is now passed as an option, allowing for more flexible configuration of excluded content in the generated documentation file.

Configuration improvements:

* Passes `starlightLllmsTxtContext.exclude` as the `exclude` option to `generateLlmsTxt` in `llms-full.txt.ts` to enable context-based exclusion of content. [[1]](diffhunk://#diff-a044f43da4e0482c52921940025a27239201df4c9ff771aa638035fbb482b612R2) [[2]](diffhunk://#diff-a044f43da4e0482c52921940025a27239201df4c9ff771aa638035fbb482b612R13)

fix https://github.com/delucis/starlight-llms-txt/issues/27