### PR TITLE
fix: avoid eager Astro container initialization

### DIFF
--- a/.changeset/lazy-raw-content-container.md
+++ b/.changeset/lazy-raw-content-container.md
@@ -1,0 +1,8 @@
+---
+'starlight-llms-txt': patch
+---
+
+Delay creating the Astro container until it is actually needed. This avoids
+eager `experimental_AstroContainer.create()` calls when `rawContent: true` is
+enabled, which can fail during Cloudflare prerender builds even though the raw
+content path does not need the container.

--- a/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
+++ b/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
@@ -28,9 +28,17 @@ const minify = { ...minifyDefaults, ...starlightLllmsTxtContext.minify };
 const selectors = [...minify.customSelectors];
 if (minify.details) selectors.unshift('details');
 
-const astroContainer = await experimental_AstroContainer.create({
-	renderers: [{ name: 'astro:jsx', ssr: mdxServer }],
-});
+let astroContainerPromise: Promise<experimental_AstroContainer> | undefined;
+
+function getAstroContainer() {
+	if (!astroContainerPromise) {
+		astroContainerPromise = experimental_AstroContainer.create({
+			renderers: [{ name: 'astro:jsx', ssr: mdxServer }],
+		});
+	}
+
+	return astroContainerPromise;
+}
 
 const htmlToMarkdownPipeline = unified()
 	.use(rehypeParse, { fragment: true })
@@ -180,6 +188,7 @@ export async function entryToSimpleMarkdown(
 	}
 
 	const { Content } = await render(entry);
+	const astroContainer = await getAstroContainer();
 	const html = await astroContainer.renderToString(Content, context);
 	const file = await htmlToMarkdownPipeline.process({
 		value: html,


### PR DESCRIPTION
Delay `experimental_AstroContainer.create()` until the non-`rawContent` path is used. This prevents Cloudflare prerender builds from failing when `rawContent` is enabled and the container is never actually needed.

Example failure reproduced from a Starlight site using Astro 6 and the Cloudflare adapter:

```
TypeError: Invalid URL string
  at createManifest (...)
  at experimental_AstroContainer.create (...)
  at entryToSimpleMarkdown (...)
  at generateLlmsTxt (...)
  at GET for /llms-full.txt and /llms-small.txt
```