### PR TITLE
fix: strip HTML comments from llms.txt output

### DIFF
--- a/.changeset/wet-banks-join.md
+++ b/.changeset/wet-banks-join.md
@@ -1,0 +1,5 @@
+---
+"starlight-llms-txt": patch
+---
+
+Strips HTML comments from llms.txt files. `<!-- ...  -->` style comments in `.md` files are no longer emitted in the generated files.

--- a/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
+++ b/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
@@ -71,7 +71,7 @@ const htmlToMarkdownPipeline = unified()
 				const figcaption = select('figcaption', instance);
 				if (figcaption) {
 					const terminalWindowTextIndex = figcaption.children.findIndex((child) =>
-						matches('span.sr-only', child)
+						matches('span.sr-only', child),
 					);
 					if (terminalWindowTextIndex > -1) {
 						figcaption.children.splice(terminalWindowTextIndex, 1);
@@ -161,7 +161,7 @@ const htmlToMarkdownPipeline = unified()
 	})
 	.use(function removeHtmlComments() {
 		return (tree) => {
-			remove(tree, (_node) => _node.type === 'comment');
+			remove(tree, ({ type }) => type === 'comment');
 		};
 	})
 	.use(rehypeRemark)
@@ -172,7 +172,7 @@ const htmlToMarkdownPipeline = unified()
 export async function entryToSimpleMarkdown(
 	entry: CollectionEntry<'docs'>,
 	context: APIContext,
-	shouldMinify: boolean = false
+	shouldMinify: boolean = false,
 ) {
 	const { rawContent } = starlightLllmsTxtContext;
 

--- a/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
+++ b/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
@@ -159,6 +159,11 @@ const htmlToMarkdownPipeline = unified()
 			}
 		};
 	})
+	.use(function removeHtmlComments() {
+		return (tree) => {
+			remove(tree, (_node) => _node.type === 'comment');
+		};
+	})
 	.use(rehypeRemark)
 	.use(remarkGfm)
 	.use(remarkStringify);


### PR DESCRIPTION
## Summary

- Adds a `removeHtmlComments` rehype plugin step that removes HAST comment nodes before the rehype-to-remark conversion
- Uses the already-imported `remove` utility from `unist-util-remove`
- Follows the same plugin pattern as the existing `minifyLlmsTxt`, `improveExpressiveCodeHandling`, etc.
- Strips `<!-- markdownlint ignore -->`, `<!-- TODO -->`, and similar HTML comments from the generated output

Closes #63

## Test plan

- [ ] Verify `<!-- ... -->` HTML comments no longer appear in generated `llms.txt` / `llms-full.txt`
- [ ] Verify non-comment content is unchanged