### PR TITLE
Preserve fenced code-block newlines when minifying whitespace

### DIFF
--- a/.changeset/collapse-code-blocks-option.md
+++ b/.changeset/collapse-code-blocks-option.md
@@ -1,9 +1,9 @@
 ---
-'starlight-llms-txt': patch
+'starlight-llms-txt': minor
 ---
 
 Preserve the contents of fenced code blocks when collapsing whitespace in `llms-small.txt`.
 
 Previously, the `minify.whitespace` option collapsed every whitespace run — including newlines inside fenced code blocks — into a single space, so multi-line code samples ended up on one line. Now, fenced code blocks (` ``` ` and `~~~`, of any fence length ≥ 3) keep their original newlines and indentation while whitespace in prose still collapses for token efficiency.
 
-A new `minify.preserveCodeBlocks` option (default `true`) controls the new behavior. Set it to `false` to restore the previous flatten-everything output.
+A new `minify.collapseCodeBlocks` option (default `false`) controls the new behavior. Set it to `true` to restore the previous flatten-everything output.

--- a/.changeset/collapse-code-blocks-option.md
+++ b/.changeset/collapse-code-blocks-option.md
@@ -2,8 +2,8 @@
 'starlight-llms-txt': minor
 ---
 
-Preserve the contents of fenced code blocks when collapsing whitespace in `llms-small.txt`.
+Preserves the contents of code blocks when collapsing whitespace in `llms-small.txt`.
 
-Previously, the `minify.whitespace` option collapsed every whitespace run — including newlines inside fenced code blocks — into a single space, so multi-line code samples ended up on one line. Now, fenced code blocks (` ``` ` and `~~~`, of any fence length ≥ 3) keep their original newlines and indentation while whitespace in prose still collapses for token efficiency.
+Previously, the `minify.whitespace` option collapsed every whitespace run — including newlines inside fenced code blocks — into a single space, so multi-line code samples ended up on one line. Now, fenced code blocks keep their original newlines and indentation while whitespace in prose still collapses for token efficiency.
 
-A new `minify.collapseCodeBlocks` option (default `false`) controls the new behavior. Set it to `true` to restore the previous flatten-everything output.
+A new `minify.collapseCodeBlocks` option controls this behavior. Set it to `true` to restore the previous flatten-everything output.

--- a/.changeset/preserve-code-blocks-in-minify.md
+++ b/.changeset/preserve-code-blocks-in-minify.md
@@ -1,0 +1,9 @@
+---
+'starlight-llms-txt': patch
+---
+
+Preserve the contents of fenced code blocks when collapsing whitespace in `llms-small.txt`.
+
+Previously, the `minify.whitespace` option collapsed every whitespace run — including newlines inside fenced code blocks — into a single space, so multi-line code samples ended up on one line. Now, fenced code blocks (` ``` ` and `~~~`, of any fence length ≥ 3) keep their original newlines and indentation while whitespace in prose still collapses for token efficiency.
+
+A new `minify.preserveCodeBlocks` option (default `true`) controls the new behavior. Set it to `false` to restore the previous flatten-everything output.

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -237,7 +237,24 @@ Exclude the `<details>` HTML element.
 **Default:** `true`
 
 Collapse whitespace.
-When `minify.whitespace` is set to `true`, all whitespace — including new lines — is collapsed to a single space character.
+When `minify.whitespace` is set to `true`, all whitespace — including new lines — is collapsed to a single space character. By default, [`minify.preserveCodeBlocks`](#minifypreservecodeblocks) keeps the contents of fenced code blocks intact so multi-line code samples stay readable.
+
+#### `minify.preserveCodeBlocks`
+
+**Type:** `boolean`  
+**Default:** `true`
+
+When [`minify.whitespace`](#minifywhitespace) is enabled, preserve the original newlines (and indentation) inside fenced code blocks (` ``` ` and `~~~`) so multi-line code samples stay multi-line in `llms-small.txt`. Whitespace in prose (paragraphs, lists, etc.) is still collapsed for token efficiency — only code-block bodies are exempt. Both variable-length fences (e.g. four or more backticks) and tilde fences are recognized.
+
+Set this to `false` to restore the previous behavior of collapsing every whitespace run — including newlines inside code fences — into a single space:
+
+```js
+minify: {
+	preserveCodeBlocks: false,
+},
+```
+
+Has no effect when `minify.whitespace` is `false`.
 
 ### `pageSeparator`
 

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -237,20 +237,20 @@ Exclude the `<details>` HTML element.
 **Default:** `true`
 
 Collapse whitespace.
-When `minify.whitespace` is set to `true`, all whitespace — including new lines — is collapsed to a single space character. By default, [`minify.preserveCodeBlocks`](#minifypreservecodeblocks) keeps the contents of fenced code blocks intact so multi-line code samples stay readable.
+When `minify.whitespace` is set to `true`, all whitespace — including new lines — is collapsed to a single space character, except inside fenced code blocks. Set [`minify.collapseCodeBlocks`](#minifycollapsecodeblocks) to `true` to collapse whitespace inside fenced code blocks as well.
 
-#### `minify.preserveCodeBlocks`
+#### `minify.collapseCodeBlocks`
 
 **Type:** `boolean`  
-**Default:** `true`
+**Default:** `false`
 
-When [`minify.whitespace`](#minifywhitespace) is enabled, preserve the original newlines (and indentation) inside fenced code blocks (` ``` ` and `~~~`) so multi-line code samples stay multi-line in `llms-small.txt`. Whitespace in prose (paragraphs, lists, etc.) is still collapsed for token efficiency — only code-block bodies are exempt. Both variable-length fences (e.g. four or more backticks) and tilde fences are recognized.
+When [`minify.whitespace`](#minifywhitespace) is enabled, also collapse whitespace inside fenced code blocks (` ``` ` and `~~~`). By default, the bodies of fenced code blocks keep their original newlines (and indentation) so multi-line code samples stay multi-line in `llms-small.txt`. Both variable-length fences (e.g. four or more backticks) and tilde fences are recognized.
 
-Set this to `false` to restore the previous behavior of collapsing every whitespace run — including newlines inside code fences — into a single space:
+Set this to `true` to collapse every whitespace run — including newlines inside code fences — into a single space:
 
 ```js
 minify: {
-	preserveCodeBlocks: false,
+	collapseCodeBlocks: true,
 },
 ```
 

--- a/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
+++ b/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
@@ -20,7 +20,7 @@ const minifyDefaults = {
 	danger: false,
 	details: true,
 	whitespace: true,
-	preserveCodeBlocks: true,
+	collapseCodeBlocks: false,
 	customSelectors: [],
 };
 /** Resolved minification options */
@@ -193,7 +193,9 @@ export async function entryToSimpleMarkdown(
 	});
 	let markdown = String(file).trim();
 	if (shouldMinify && minify.whitespace) {
-		if (minify.preserveCodeBlocks) {
+		if (minify.collapseCodeBlocks) {
+			markdown = markdown.replace(/\s+/g, ' ');
+		} else {
 			// Collapse whitespace in prose, but keep the contents of fenced code
 			// blocks (``` and ~~~, of any length ≥ 3) intact so multi-line code
 			// samples stay multi-line. Fences are matched at the start of a line
@@ -215,8 +217,6 @@ export async function entryToSimpleMarkdown(
 			// input; trim again so the `\n` wrappers we added around fences at
 			// the start/end of the document don't reintroduce it.
 			markdown = parts.join('').trim();
-		} else {
-			markdown = markdown.replace(/\s+/g, ' ');
 		}
 	}
 	return markdown;

--- a/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
+++ b/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
@@ -198,18 +198,23 @@ export async function entryToSimpleMarkdown(
 			// blocks (``` and ~~~, of any length ≥ 3) intact so multi-line code
 			// samples stay multi-line. Fences are matched at the start of a line
 			// and the closing fence must use the same marker length and
-			// indentation as the opener (via back-references).
+			// indentation as the opener (via back-references). The body chunk is
+			// optional so empty fences (`` ```\n``` ``) still match.
 			const fenceMatcher =
-				/(?<=^|\n)([ \t]*)(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1\2[ \t]*(?=\n|$)/g;
+				/(?<=^|\n)([ \t]*)(`{3,}|~{3,})[^\n]*\n(?:[\s\S]*?\n)?\1\2[ \t]*(?=\n|$)/g;
 			const parts: string[] = [];
 			let lastIndex = 0;
 			for (const match of markdown.matchAll(fenceMatcher)) {
-				parts.push(markdown.slice(lastIndex, match.index).replace(/\s+/g, ' '));
+				const index = match.index ?? 0;
+				parts.push(markdown.slice(lastIndex, index).replace(/\s+/g, ' '));
 				parts.push('\n', match[0], '\n');
-				lastIndex = match.index + match[0].length;
+				lastIndex = index + match[0].length;
 			}
 			parts.push(markdown.slice(lastIndex).replace(/\s+/g, ' '));
-			markdown = parts.join('');
+			// `String(file).trim()` already stripped boundary whitespace from the
+			// input; trim again so the `\n` wrappers we added around fences at
+			// the start/end of the document don't reintroduce it.
+			markdown = parts.join('').trim();
 		} else {
 			markdown = markdown.replace(/\s+/g, ' ');
 		}

--- a/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
+++ b/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
@@ -20,6 +20,7 @@ const minifyDefaults = {
 	danger: false,
 	details: true,
 	whitespace: true,
+	preserveCodeBlocks: true,
 	customSelectors: [],
 };
 /** Resolved minification options */
@@ -192,7 +193,26 @@ export async function entryToSimpleMarkdown(
 	});
 	let markdown = String(file).trim();
 	if (shouldMinify && minify.whitespace) {
-		markdown = markdown.replace(/\s+/g, ' ');
+		if (minify.preserveCodeBlocks) {
+			// Collapse whitespace in prose, but keep the contents of fenced code
+			// blocks (``` and ~~~, of any length ≥ 3) intact so multi-line code
+			// samples stay multi-line. Fences are matched at the start of a line
+			// and the closing fence must use the same marker length and
+			// indentation as the opener (via back-references).
+			const fenceMatcher =
+				/(?<=^|\n)([ \t]*)(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1\2[ \t]*(?=\n|$)/g;
+			const parts: string[] = [];
+			let lastIndex = 0;
+			for (const match of markdown.matchAll(fenceMatcher)) {
+				parts.push(markdown.slice(lastIndex, match.index).replace(/\s+/g, ' '));
+				parts.push('\n', match[0], '\n');
+				lastIndex = match.index + match[0].length;
+			}
+			parts.push(markdown.slice(lastIndex).replace(/\s+/g, ' '));
+			markdown = parts.join('');
+		} else {
+			markdown = markdown.replace(/\s+/g, ' ');
+		}
 	}
 	return markdown;
 }

--- a/packages/starlight-llms-txt/types.ts
+++ b/packages/starlight-llms-txt/types.ts
@@ -131,22 +131,25 @@ export interface StarlightLllmsTextOptions {
 		whitespace?: boolean;
 
 		/**
-		 * When `whitespace` is enabled, preserve the original newlines (and
-		 * indentation) inside fenced code blocks (``` and ~~~) so that
-		 * multi-line code samples stay multi-line in `llms-small.txt`.
+		 * When `whitespace` is enabled, also collapse whitespace inside fenced
+		 * code blocks (``` and ~~~). By default, the bodies of fenced code
+		 * blocks keep their original newlines (and indentation) so multi-line
+		 * code samples stay multi-line in `llms-small.txt`.
 		 *
-		 * Whitespace in prose (paragraphs, lists, etc.) is still collapsed for
-		 * token efficiency — only code-block bodies are exempt. Both
-		 * variable-length fences (e.g. four or more backticks) and tilde fences
-		 * are recognized. Has no effect when `whitespace` is `false`.
+		 * Whitespace in prose (paragraphs, lists, etc.) is always collapsed
+		 * when `whitespace` is enabled; this option only controls whether
+		 * code-block bodies are exempt. Both variable-length fences (e.g.
+		 * four or more backticks) and tilde fences are recognized.
 		 *
-		 * Set this to `false` to restore the previous behavior of collapsing
+		 * Set this to `true` to restore the previous behavior of collapsing
 		 * every whitespace run, including newlines inside code fences, into a
 		 * single space.
 		 *
-		 * @default true
+		 * Has no effect when `whitespace` is `false`.
+		 *
+		 * @default false
 		 */
-		preserveCodeBlocks?: boolean;
+		collapseCodeBlocks?: boolean;
 
 		/**
 		 * Custom selectors to exclude when generating `llms-small.txt`.

--- a/packages/starlight-llms-txt/types.ts
+++ b/packages/starlight-llms-txt/types.ts
@@ -131,6 +131,24 @@ export interface StarlightLllmsTextOptions {
 		whitespace?: boolean;
 
 		/**
+		 * When `whitespace` is enabled, preserve the original newlines (and
+		 * indentation) inside fenced code blocks (``` and ~~~) so that
+		 * multi-line code samples stay multi-line in `llms-small.txt`.
+		 *
+		 * Whitespace in prose (paragraphs, lists, etc.) is still collapsed for
+		 * token efficiency — only code-block bodies are exempt. Both
+		 * variable-length fences (e.g. four or more backticks) and tilde fences
+		 * are recognized. Has no effect when `whitespace` is `false`.
+		 *
+		 * Set this to `false` to restore the previous behavior of collapsing
+		 * every whitespace run, including newlines inside code fences, into a
+		 * single space.
+		 *
+		 * @default true
+		 */
+		preserveCodeBlocks?: boolean;
+
+		/**
 		 * Custom selectors to exclude when generating `llms-small.txt`.
 		 *
 		 * @default []


### PR DESCRIPTION
## Summary

`minify.whitespace` (used when generating `llms-small.txt`) currently runs
`markdown.replace(/\s+/g, ' ')` which collapses every whitespace run — including
newlines **inside** fenced code blocks — into a single space. Multi-line code
samples are flattened onto one line, and downstream LLM consumers render them
as flowed prose.

Concrete example from a real site that uses this plugin (aspire.dev):

```text
Trust the development certificate \`\`\`bash aspire certs trust \`\`\` Remove and re-trust
```

…where the `aspire certs trust` command should be on its own line inside the fence.

## Change

When `minify.whitespace` is enabled and the new
`minify.preserveCodeBlocks` option is `true` (its default), the algorithm
now:

1. Finds fenced code blocks via a lookbehind anchored to the start of a line:
   `(?<=^|\n)([ \t]*)(\`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1\2[ \t]*(?=\n|$)`
2. Collapses whitespace only in the prose chunks between matched fences.
3. Wraps each preserved fence with single newlines so it stays on its own
   lines in the output.

Properties:

- Variable-length fences are supported (e.g. four or more backticks for code
  bodies that themselves contain \`\`\`).
- Closing fence must match the opener's marker length and indentation
  (via `\1\2` back-references), so fences nested under list items keep
  their indentation.
- Inline triple-backticks in prose are not misclassified — the lookbehind
  requires the fence to begin at a line start.

`minify.preserveCodeBlocks: false` restores the legacy flatten-everything
behavior, so users who depend on that output (e.g. for byte-exact diffs) can
opt out.

## Why `true` as the default

This is fundamentally a bug fix — the flattened output is almost certainly
not what users of `llms-small.txt` want for code samples. The option is the
escape hatch, not the opt-in. Happy to flip it to opt-in if you'd rather ship
this as additive-only.

## Tested

- Local Node fixture suite covering plain prose, single/adjacent fences,
  4-backtick + literal \`\`\` body, tilde fences, list-nested fences with
  indentation, inline triple-backtick in prose, fence at start/end of input,
  and mismatched fence lengths. All cases pass.
- Validated against the real aspire.dev `llms-small.txt` content via a
  patched local copy of the plugin; previously-collapsed code blocks now
  render multi-line correctly.

Happy to add a `vitest` (or whichever runner you prefer) test harness in
`packages/starlight-llms-txt/tests/` if you'd like that landed as part of
this PR.

## Changeset

Included `.changeset/preserve-code-blocks-in-minify.md` as a `patch` bump.

---

Downstream tracking: this is also being applied as a `pnpm patch` in
microsoft/aspire.dev as an immediate mitigation; that patch will be removed
when a new `starlight-llms-txt` release containing this fix is published.