### PR TITLE
Qualify in-page fragment links per page so llms-full.txt isn't ambiguous

### DIFF
--- a/.changeset/qualify-fragment-links.md
+++ b/.changeset/qualify-fragment-links.md
@@ -1,0 +1,7 @@
+---
+'starlight-llms-txt': minor
+---
+
+Resolve in-page fragment links per page so they stay unambiguous in concatenated output
+
+In-page links such as `[Renderers](#renderers)` were copied verbatim into the generated Markdown. Once every page is concatenated into `llms-full.txt` (and `llms-small.txt` / custom sets), a bare `#renderers` no longer identifies which page it belongs to. Such links are now resolved against the page being processed and kept **root-relative** — e.g. `#renderers` becomes `/docs/guide/#renderers` — so they stay unambiguous after concatenation while remaining host- and version-neutral (important for sites served from multiple hosts/versions).

--- a/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
+++ b/packages/starlight-llms-txt/entryToSimpleMarkdown.ts
@@ -11,6 +11,7 @@ import remarkStringify from 'remark-stringify';
 import { unified } from 'unified';
 import { remove } from 'unist-util-remove';
 import { starlightLllmsTxtContext } from 'virtual:starlight-llms-txt/context';
+import { ensureTrailingSlash } from './utils';
 
 /** Minification defaults */
 const minifyDefaults = {
@@ -197,6 +198,19 @@ const htmlToMarkdownPipeline = unified()
 			remove(tree, ({ type }) => type === 'comment');
 		};
 	})
+	.use(function qualifyFragmentLinks() {
+		// Resolve in-page fragment links against the page being processed so they
+		// stay unambiguous once pages are concatenated into `llms-full.txt`. Kept
+		// root-relative (never an absolute host) so multi-host / multi-version
+		// sites resolve them correctly. Only hrefs starting with `#` are touched.
+		return (tree, file) => {
+			const base = file.data.starlightLlmsTxt.pagePath;
+			if (!base) return;
+			for (const anchor of selectAll('a[href^="#"]', tree)) {
+				anchor.properties.href = base + (anchor.properties.href as string);
+			}
+		};
+	})
 	.use(rehypeRemark)
 	.use(remarkGfm)
 	.use(remarkStringify);
@@ -219,9 +233,15 @@ export async function entryToSimpleMarkdown(
 
 	const { Content } = await render(entry);
 	const html = await astroContainer.renderToString(Content, context);
+	// Starlight routes `index` entries to their parent directory ('' for the
+	// site root), so drop a trailing `index` segment before building the path.
+	const slug = entry.id === 'index' ? '' : entry.id.replace(/\/index$/, '');
+	const pagePath = ensureTrailingSlash(
+		ensureTrailingSlash(starlightLllmsTxtContext.base) + slug
+	);
 	const file = await htmlToMarkdownPipeline.process({
 		value: html,
-		data: { starlightLlmsTxt: { minify: shouldMinify } },
+		data: { starlightLlmsTxt: { minify: shouldMinify, pagePath } },
 	});
 	let markdown = String(file).trim();
 	if (shouldMinify && minify.whitespace) {

--- a/packages/starlight-llms-txt/env.d.ts
+++ b/packages/starlight-llms-txt/env.d.ts
@@ -8,6 +8,10 @@ declare module 'vfile' {
 	interface DataMap {
 		starlightLlmsTxt: {
 			minify: boolean;
+			/** Root-relative path of the page being processed. Used to qualify
+			 * in-page fragment links (`#foo`) so they stay unambiguous once pages
+			 * are concatenated into `llms-full.txt`. */
+			pagePath?: string;
 		};
 	}
 }


### PR DESCRIPTION
## Problem

`entryToSimpleMarkdown` copies in-page links verbatim from the rendered HTML, and `generator.ts` concatenates every page into one file. A bare fragment link is fine on its own page but ambiguous once many pages share `llms-full.txt`:

> See the [Renderers](#renderers) section.

In the concatenated file there can be many `#renderers`-style anchors, and `#renderers` alone no longer identifies which page it belongs to — a consumer (LLM/agent) can't resolve it. (Same applies to `llms-small.txt` and custom sets.)

## Change

A small hast transform (`qualifyFragmentLinks`) inserted just before `rehypeRemark` rewrites links whose `href` starts with `#`, prefixing them with the page's own path:

```
#renderers  ->  /<base>/<page-path>/#renderers
```

- The page path rides the existing `file.data.starlightLlmsTxt` channel (same mechanism as `minify`), derived from `context.base` + the entry id (with the `index` -> parent-directory rule).
- Reuses the already-imported `selectAll` from `hast-util-select`, so **no new dependency**.
- Only `href`s starting with `#` are touched, so existing absolute/cross-page links are untouched. `rawContent` mode early-returns before the pipeline, so it's unaffected.

**Kept root-relative, never absolute** — some sites serve the same content from multiple hosts/versions (e.g. `docs.slint.dev/latest/…` and `releases.slint.dev/<version>/…`); root-relative links resolve correctly on each, whereas absolutizing to a fixed host would break the per-version copies.

## Verification

Built this repo's own docs site (`pnpm build:docs`) and inspected the generated `llms-full.txt`:

- bare `](#…)` links remaining: **0** (all qualified)
- home page (`index.mdx`): `](#demo)` -> `](/starlight-llms-txt/#demo)` ✅ (site root, not `/index/`)
- content page: `](#options)` -> `](/starlight-llms-txt/configuration/#options)` ✅
- absolute / cross-page links: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
