### PR TITLE
docs: suggest validating the deployed llms.txt in CI

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -50,6 +50,16 @@ import { PackageManagers } from 'starlight-package-managers';
 
 </Steps>
 
+## Validating the deployed output
+
+The plugin generates a correct `llms.txt` at build time, but serving-layer config can break it in production: host redirect rules, domain migrations, and docs restructures all bite after the build goes green. [llms-txt-check](https://github.com/portdeveloper/llms-txt-check) verifies the deployed file against what your site actually serves:
+
+```yaml
+- run: npx llms-txt-check https://example.com
+```
+
+It exits nonzero when the file or any listed URL stops serving, so the deploy that breaks a route goes red.
+
 ## Next steps
 
 See the [Configuration](/starlight-llms-txt/configuration/) guide to learn how to adjust the output of the plugin.


### PR DESCRIPTION
hey! i built a checker that validates deployed llms.txt files against what the site actually serves. the breakage i keep finding on production sites is never the generator's fault: host redirects, domain migrations, and docs restructures all happen after the build is green (drizzle lost 71 links this way, drizzle-team/drizzle-orm-docs#705; cursor's moved docs serve HTML at the old llms.txt URL). this PR adds a short section to the getting-started guide pointing starlight users at a one-line CI check so your plugin's output stays healthy in production. happy to reword or trim!